### PR TITLE
Update vmss-mz.ps1

### DIFF
--- a/patterns/vmss/vmss-mz.ps1
+++ b/patterns/vmss/vmss-mz.ps1
@@ -55,6 +55,7 @@ $vmssConfig = New-AzVmssConfig `
     -SkuCapacity 3 `
     -SkuName "Standard_D2s_v5" `
     -UpgradePolicyMode "Automatic" `
+    -OrchestrationMode "Flexible" `
     -Zone 1,2,3 `
     -ZoneBalance $true |
     Set-AzVmssStorageProfile `

--- a/patterns/vmss/vmss-mz.ps1
+++ b/patterns/vmss/vmss-mz.ps1
@@ -56,6 +56,7 @@ $vmssConfig = New-AzVmssConfig `
     -SkuName "Standard_D2s_v5" `
     -UpgradePolicyMode "Automatic" `
     -OrchestrationMode "Flexible" `
+    -PlatformFaultDomainCount 1 `
     -Zone 1,2,3 `
     -ZoneBalance $true |
     Set-AzVmssStorageProfile `


### PR DESCRIPTION
VMSS Flex is what the PG will be pushing moving forward especially to replace AvSet. There is param called -PlatformFaultDomainCount, tested it and found it in the doco as well, max spreading means platformfaultdomaincount = 1

https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones#availability-considerations

In Azure Portal:
<img width="619" alt="image" src="https://github.com/tsc-buddy/WA-MZ-MR-Patterns/assets/8053228/8193e77e-b806-4a22-adaa-f77849d5485a">
